### PR TITLE
하단 네비게이션 바 생성 및 3개 메뉴에 대한 페이지 링크 설정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,32 @@
+import { Route, Routes } from 'react-router-dom';
+
+import styled from 'styled-components';
+import { Reset } from 'styled-reset';
+
+import HomePage from './pages/HomePage';
+import MapPage from './pages/MapPage';
+import MyPage from './pages/MyPage';
+import TopThreePage from './pages/TopThreePage';
+
+import NavigationBar from './components/NavigationBar';
+import GlobalStyle from './styles/GlobalStyle';
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+`;
+
 export default function App() {
   return (
-    <p>
-      Hello, world!
-    </p>
+    <Wrapper>
+      <Reset />
+      <GlobalStyle />
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/map" element={<MapPage />} />
+        <Route path="/top3" element={<TopThreePage />} />
+        <Route path="/myaccount" element={<MyPage />} />
+      </Routes>
+      <NavigationBar />
+    </Wrapper>
   );
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
+
+import { MemoryRouter } from 'react-router-dom';
+
 import App from './App';
 
 test('App', () => {
-  render(<App />);
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  );
 
-  screen.getByText(/Hello/);
+  screen.getByText(/Home Page/);
 });

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,0 +1,7 @@
+export default function Map() {
+  return (
+    <div>
+      Map Page
+    </div>
+  );
+}

--- a/src/components/Map.test.jsx
+++ b/src/components/Map.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+
+import Map from './Map';
+
+test('Map', () => {
+  render(<Map />);
+});

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom';
+
+import styled from 'styled-components';
+
+const NaviBar = styled.nav`
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 4em;
+    background-color: #DDD;
+`;
+
+const List = styled.ul`
+    display: flex;
+    li {
+        margin-inline: 3em;
+    }
+`;
+
+export default function NavigationBar() {
+  return (
+    <NaviBar>
+      <List>
+        <li>
+          <Link to="/map">지도 검색</Link>
+        </li>
+        <li>
+          <Link to="/top3">Top 3</Link>
+        </li>
+        <li>
+          <Link to="/myaccount">My메뉴</Link>
+        </li>
+      </List>
+    </NaviBar>
+  );
+}

--- a/src/components/NavigationBar.test.jsx
+++ b/src/components/NavigationBar.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import NavigationBar from './NavigationBar';
+
+jest.mock('react-router-dom', () => ({
+  Link({ to, children }) {
+    return (
+      <a href={to}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+test('Navigation Bar', () => {
+  render(<NavigationBar />);
+
+  screen.getByText('지도 검색');
+  screen.getByText('Top 3');
+  screen.getByText('My메뉴');
+});

--- a/src/components/TopThreePlaces.jsx
+++ b/src/components/TopThreePlaces.jsx
@@ -1,0 +1,7 @@
+export default function TopThreePlaces() {
+  return (
+    <p>
+      Top 3 Page
+    </p>
+  );
+}

--- a/src/components/TopThreePlaces.test.jsx
+++ b/src/components/TopThreePlaces.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import TopThreePlaces from './TopThreePlaces';
+
+test('TopThreePlaces', () => {
+  render(<TopThreePlaces />);
+
+  screen.getByText('Top 3 Page');
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,13 @@
 import ReactDOM from 'react-dom/client';
+
+import { BrowserRouter } from 'react-router-dom';
+
 import App from './App';
 
 const container = document.getElementById('app');
 const root = ReactDOM.createRoot(container);
 root.render((
-  <App />
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 ));

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,7 @@
+export default function HomePage() {
+  return (
+    <p>
+      Home Page
+    </p>
+  );
+}

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import HomePage from './HomePage';
+
+test('HomePage', () => {
+  render(<HomePage />);
+
+  screen.getByText('Home Page');
+});

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -1,0 +1,7 @@
+import Map from '../components/Map';
+
+export default function MapPage() {
+  return (
+    <Map />
+  );
+}

--- a/src/pages/MapPage.test.jsx
+++ b/src/pages/MapPage.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import MapPage from './MapPage';
+
+test('MapPage', () => {
+  render(<MapPage />);
+
+  screen.getByText('Map Page');
+});

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,7 @@
+export default function MyPage() {
+  return (
+    <p>
+      My Page
+    </p>
+  );
+}

--- a/src/pages/MyPage.test.jsx
+++ b/src/pages/MyPage.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+
+import MyPage from './MyPage';
+
+test('MyPage', () => {
+  render(<MyPage />);
+
+  screen.getByText('My Page');
+});

--- a/src/pages/TopThreePage.jsx
+++ b/src/pages/TopThreePage.jsx
@@ -1,0 +1,7 @@
+import TopThreePlaces from '../components/TopThreePlaces';
+
+export default function TopThreePage() {
+  return (
+    <TopThreePlaces />
+  );
+}

--- a/src/pages/TopThreePage.test.jsx
+++ b/src/pages/TopThreePage.test.jsx
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react';
+import TopThreePage from './TopThreePage';
+
+test('TopThreePage', () => {
+  render(<TopThreePage />);
+});

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -1,0 +1,21 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+* {
+    box-sizing: border-box;
+}
+
+a {
+    text-decoration: none;
+}
+
+ul {
+    list-style: none;
+}
+
+button {
+    cursor: pointer;
+}
+`;
+
+export default GlobalStyle;


### PR DESCRIPTION
---

"/" : Home Page
<img width="455" alt="스크린샷 2022-10-27 오후 9 43 54" src="https://user-images.githubusercontent.com/104840243/198288346-615d5418-d0f6-4b21-9aa8-25e0f8715640.png">

---

"/map" : Map Page
<img width="420" alt="스크린샷 2022-10-27 오후 9 44 37" src="https://user-images.githubusercontent.com/104840243/198288461-907ffc62-546c-4042-a9cc-eee0056f3b5d.png">

---

"/top3" : Top 3 Page
<img width="401" alt="스크린샷 2022-10-27 오후 9 44 43" src="https://user-images.githubusercontent.com/104840243/198288528-1e90882b-e410-4de1-b33e-8cd5eeec73a9.png">

---

"/myaccount" : My Page
<img width="455" alt="스크린샷 2022-10-27 오후 9 44 51" src="https://user-images.githubusercontent.com/104840243/198288577-e2fe244a-77a9-42fa-bf51-63b8646998d4.png">
