### PR TITLE
맵 컴포넌트에 카카오 맵 api 활용하여 지도 삽입 및 초기위치(덕수궁. 시청근처) 지정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>아빠! 오늘은 어디가요?</title>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=91eb5a667cada49aaa99f4f14a7a7b1c"></script>
 </head>
 <body>
   <div id="app">

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,7 +1,10 @@
+import MapContainer from './MapContainer';
+
 export default function Map() {
   return (
     <div>
       Map Page
+      <MapContainer />
     </div>
   );
 }

--- a/src/components/MapContainer.jsx
+++ b/src/components/MapContainer.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import KakaoMap from '../modules/KakaoMapModule';
+
+function MapContainer() {
+  useEffect(() => {
+    KakaoMap();
+  }, []);
+
+  return (
+    <div
+      id="map"
+      style={{
+        width: '500px',
+        height: '500px',
+      }}
+    />
+  );
+}
+
+export default MapContainer;

--- a/src/modules/KakaoMapModule.jsx
+++ b/src/modules/KakaoMapModule.jsx
@@ -1,0 +1,10 @@
+const { kakao } = window;
+
+export default function KakaoMap() {
+  const container = document.getElementById('map');
+  const options = {
+    center: new kakao.maps.LatLng(37.565984, 126.975373),
+    level: 3,
+  };
+  const map = new kakao.maps.Map(container, options);
+}


### PR DESCRIPTION
카카오 맵 api 가이드 참고하여
- MapContainer.jsx 생성 및 Map 컴포넌트에 추가
- 시청 근처 유적지인 덕수궁 위도/경도 값을 구한 뒤 지도 초기 위치로 지정
- 개발자도구 하단 메시지는 카카오 디벨로퍼스 답변 확인 결과 느린 네트워크 상 스크립트 블락이 일어날 수 있다는 문구이며, 지고 동작에는 문제가 없어 기업 차원에서 정책적으로 대응하지 않겠다고 결정한 사항 확인
(https://devtalk.kakao.com/t/kakao-map-loading-console-parser-blocking-message/77540/2)

---

<img width="668" alt="스크린샷 2022-10-28 오후 12 30 56" src="https://user-images.githubusercontent.com/104840243/198496484-958fd320-64b3-4e97-95f6-194772773e42.png">
