### PR TITLE
DB의 장소정보 기반으로 마커 생성 시 일정 확대 레벨에 따라 클러스터러 마커로 변환

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <div id="app">
     Loading...
   </div>
-  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=91eb5a667cada49aaa99f4f14a7a7b1c"></script>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=91eb5a667cada49aaa99f4f14a7a7b1c&libraries=services,clusterer,drawing"></script>
   <script type="module" src="./src/index.jsx"></script>
 </body>
 </html>

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -12,13 +12,14 @@ const Wrapper = styled.div`
 `;
 
 const Button = styled.button`
+  //TODO.
 `;
 
-const Image = styled.img`
-  width: 10px;
-  height: 10px;
-  object-fit: cover;
-`;
+// const Image = styled.img`
+//   width: 10px;
+//   height: 10px;
+//   object-fit: cover;
+// `;
 
 export default function FilterBar({
   handleFilterClick, sido, sigungu, category,

--- a/src/components/FilterResultBar.test.jsx
+++ b/src/components/FilterResultBar.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import FilterResultBar from './FilterResultBar';
 
 const handleFilterResultClick = jest.fn();

--- a/src/components/FilteredPlacesList.jsx
+++ b/src/components/FilteredPlacesList.jsx
@@ -1,8 +1,7 @@
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const List = styled.ul`
-    //
+    //TODO.
 `;
 
 const Place = styled.button`

--- a/src/components/FilteredPlacesList.test.jsx
+++ b/src/components/FilteredPlacesList.test.jsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+
 import FilteredPlacesList from './FilteredPlacesList';
 
 let positions;

--- a/src/components/Filters.test.jsx
+++ b/src/components/Filters.test.jsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
+
 import { mapStore } from '../stores/MapStore';
+
 import Filters from './Filters';
 
 jest.mock('react-router-dom', () => ({

--- a/src/components/PlaceCategoryFilter.test.jsx
+++ b/src/components/PlaceCategoryFilter.test.jsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+
 import PlaceCategoryFilter from './PlaceCategoryFilter';
 
 const handlePlaceCategoryClick = jest.fn();

--- a/src/components/PlaceInformationPopup.jsx
+++ b/src/components/PlaceInformationPopup.jsx
@@ -47,6 +47,7 @@ const Information = styled.div`
 const handleBookmarkClick = () => {
   // TODO. 즐겨찾기 기능 구현
 };
+
 export default function PlaceInformationPopup(
   { selectedPlace, handlePlaceInformationPopupCloseClick },
 ) {

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable no-nested-ternary */
 import { useEffect, useRef, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import styled from 'styled-components';
 
-import { useNavigate } from 'react-router-dom';
 import useMapStore from '../hooks/useMapStore';
 
 import { loadKakaoMap } from '../utils/KakaoMap';

--- a/src/pages/MapPage.test.jsx
+++ b/src/pages/MapPage.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import { MemoryRouter } from 'react-router-dom';
 
 import { loadKakaoMap } from '../utils/KakaoMap';

--- a/src/services/MapApiService.js
+++ b/src/services/MapApiService.js
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
-
 import axios from 'axios';
+
 import config from '../config';
 
 const baseUrl = config.apiBaseUrl;

--- a/src/stores/MapStore.js
+++ b/src/stores/MapStore.js
@@ -34,7 +34,6 @@ export default class MapStore {
 
   fetchSelectedPlaceInformation(id) {
     this.selectedPlace = this.positions.find((value) => value.placeId === id);
-    console.log(this.selectedPlace);
     this.publish();
   }
 

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -7,6 +7,7 @@ const GlobalStyle = createGlobalStyle`
 
 a {
     text-decoration: none;
+    color: #000;
 }
 
 ul {

--- a/src/utils/KakaoMap.js
+++ b/src/utils/KakaoMap.js
@@ -27,41 +27,77 @@ function makeOutListener(infowindow) {
 // );
 
 export function loadMarkers(positions, map, makeClickListener) {
-  positions.forEach((value) => {
+  const markers = [];
+
+  for (let i = 0; i < positions.length; i += 1) {
     const marker = new kakao.maps.Marker({
       map,
-      id: value.placeId,
-      position: new kakao.maps.LatLng(value.latitude, value.longitude),
+      id: positions[i].placeId,
+      position: new kakao.maps.LatLng(positions[i].latitude, positions[i].longitude),
     });
 
+    // 인포 윈도우 생성
     const infowindow = new kakao.maps.InfoWindow({
-      content: value.name,
+      content: positions[i].name,
     });
 
+    // 마커 위에 마우스 오버 시 인포 윈도우 띄우는 역할
     kakao.maps.event.addListener(
       marker,
       'mouseover',
       makeOverListener(map, marker, infowindow),
     );
 
+    // 마커 위에서 마우스 아웃 시 인포 윈도우 사라지는 역할
     kakao.maps.event.addListener(
       marker,
       'mouseout',
       makeOutListener(infowindow),
     );
 
+    // 마커 클릭 시 이벤트
     kakao.maps.event.addListener(
       marker,
       'click',
-      () => makeClickListener(value.placeId),
+      () => makeClickListener(positions[i].placeId),
     );
+
+    markers.push(marker);
+  }
+
+  // 마커 클러스터러 적용
+  const clusterer = new kakao.maps.MarkerClusterer({
+    map,
+    averageCenter: true, // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
+    minLevel: 10, // 클러스터 할 최소 지도 레벨
+    styles: [{ // calculator 각 사이 값 마다 적용될 스타일을 지정한다
+      width: '30px',
+      height: '30px',
+      background: 'rgba(255, 80, 80, .8)',
+      borderRadius: '15px',
+      color: '#000',
+      textAlign: 'center',
+      fontWeight: 'bold',
+      lineHeight: '31px',
+    }],
   });
+
+  // 추후 데이터가 많아졌을 때 판단하여 사용할 것(클러스터 클릭 이벤트)
+  // kakao.maps.event.addListener(clusterer, 'clusterclick', (cluster) => {
+  //   // 현재 지도 레벨에서 1레벨 확대한 레벨
+  //   const level = map.getLevel() - 1;
+
+  //   // 지도를 클릭된 클러스터의 마커의 위치를 기준으로 확대합니다
+  //   map.setLevel(level, { anchor: cluster.getCenter() });
+  // });
+
+  clusterer.addMarkers(markers);
 }
 
 export function loadKakaoMap(component, positions, makeClickListener) {
   const options = {
     center: new kakao.maps.LatLng(37.565804, 126.975146),
-    level: 10,
+    level: 12,
   };
 
   const map = new kakao.maps.Map(component, options);


### PR DESCRIPTION
- 지도 첫 화면(DB가 충분히 확보되지 않은 상황이므로 마커 동작을 확인하기 위해 축소 레벨을 아주 높여두었음)
![스크린샷 2022-11-05 오전 8 42 43](https://user-images.githubusercontent.com/104840243/200090068-ace95223-4e80-46bc-8b8b-c9bae7b73cbd.png)

---

- 클러스터 마커를 클릭하거나 우측 확대-축소바의 확대를 클릭할 경우 지정된 레벨에 따라 클러스터 마커-개별마커로 전환 및 클러스터링 되는 마커의 개수가 변경됨
![스크린샷 2022-11-05 오전 8 42 51](https://user-images.githubusercontent.com/104840243/200090159-d41811f0-9a97-42a3-ae38-ed58a02bfeb5.png)

---

- 모두 개별 마커로 확인될 수 있도록 지도를 확대한 케이스
![스크린샷 2022-11-05 오전 8 43 04](https://user-images.githubusercontent.com/104840243/200090173-3f047c6d-d51e-44d5-ad24-80bb12a7f3db.png)

