### PR TITLE
장소 상세보기 페이지 하단 연락처 navigation(bar 형태) 1차 ui 구현

### DIFF
--- a/src/components/PlaceContactBar.jsx
+++ b/src/components/PlaceContactBar.jsx
@@ -1,4 +1,4 @@
-export default function PlaceContactBar() {
+export default function PlaceContactBar({ contact }) {
   const handlePlaceContactClick = () => {
     //
   };
@@ -8,7 +8,7 @@ export default function PlaceContactBar() {
       <button type="button" onClick={handlePlaceContactClick}>연락하기</button>
       <button
         type="button"
-        onClick={() => window.open('https://megaptera.kr/', '_blank')}
+        onClick={() => window.open(contact.homepage, '_blank')}
       >
         홈페이지
       </button>

--- a/src/components/PlaceContactBar.jsx
+++ b/src/components/PlaceContactBar.jsx
@@ -1,17 +1,54 @@
+import styled from 'styled-components';
+
+const Container = styled.nav`
+  position: fixed;
+  height: 5em;
+  bottom: 0;
+  width: 600px;
+  background-color: #ff9d13;
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+  }
+`;
+
+const Phone = styled.button`
+  font-size: 1.1em;
+  font-weight: bold;
+  color: #FFF;
+  margin-inline: 5em;
+  background: none;
+  border: none;
+`;
+
+const HomePage = styled.button`
+  font-size: 1.1em;
+  font-weight: bold;
+  color: #FFF;
+  margin-inline: 5em;
+  background: none;
+  border: none;
+`;
+
 export default function PlaceContactBar({ contact }) {
   const handlePlaceContactClick = () => {
     //
   };
 
   return (
-    <div>
-      <button type="button" onClick={handlePlaceContactClick}>연락하기</button>
-      <button
-        type="button"
-        onClick={() => window.open(contact.homepage, '_blank')}
-      >
-        홈페이지
-      </button>
-    </div>
+    <Container>
+      <div>
+        <Phone type="button" onClick={handlePlaceContactClick}>연락하기</Phone>
+        <HomePage
+          type="button"
+          onClick={() => window.open(contact.homepage, '_blank')}
+        >
+          홈페이지
+        </HomePage>
+      </div>
+    </Container>
   );
 }

--- a/src/pages/PlaceDetailPage.jsx
+++ b/src/pages/PlaceDetailPage.jsx
@@ -13,7 +13,9 @@ export default function PlaceDetailPage() {
   }, []);
 
   const { selectedPlace, imageNumber } = mapStore;
-  const { imageSource, address } = selectedPlace;
+  const {
+    imageSource, address, placeServices, contact,
+  } = selectedPlace;
 
   const handlePlaceDetailCloseClick = () => {
     //
@@ -85,7 +87,7 @@ export default function PlaceDetailPage() {
               <p>미니 지도 영역</p>
             </div>
           </article>
-          <PlaceContactBar />
+          <PlaceContactBar contact={contact} />
         </div>
       ) : (
         <p>Now loading...</p>

--- a/src/pages/PlaceDetailPage.jsx
+++ b/src/pages/PlaceDetailPage.jsx
@@ -1,7 +1,15 @@
 /* eslint-disable no-nested-ternary */
 import { useEffect } from 'react';
+import styled from 'styled-components';
 import PlaceContactBar from '../components/PlaceContactBar';
 import useMapStore from '../hooks/useMapStore';
+
+const Container = styled.div`
+`;
+
+const Wrapper = styled.div`
+  
+`;
 
 export default function PlaceDetailPage() {
   const mapStore = useMapStore();
@@ -50,9 +58,9 @@ export default function PlaceDetailPage() {
   };
 
   return (
-    <div>
+    <Container>
       {selectedPlace && imageSource && address ? (
-        <div>
+        <Wrapper>
           <button type="button" onClick={handlePlaceDetailCloseClick}> &lt; 뒤로가기</button>
           <button type="button" onClick={handleBookmarkClick}> 즐겨찾기</button>
           <button type="button" onClick={handlePlaceDetailTapClick}>상세정보</button>
@@ -67,12 +75,15 @@ export default function PlaceDetailPage() {
               ) : (
                 <img src={imageSource.thirdImage} alt="" />
               )}
-              <button type="button" onClick={handlePrevImageClick}>이전이미지로</button>
-              <p>
-                {imageNumber}
-                /3
-              </p>
-              <button type="button" onClick={handlNextImageClick}>다음이미지로</button>
+              <div>
+                <button type="button" onClick={handlePrevImageClick}>&lt;</button>
+                <span>
+                  {imageNumber}
+                  {' '}
+                  / 3
+                </span>
+                <button type="button" onClick={handlNextImageClick}>&gt;</button>
+              </div>
             </div>
             <div>
               <h2>{selectedPlace.name}</h2>
@@ -88,10 +99,10 @@ export default function PlaceDetailPage() {
             </div>
           </article>
           <PlaceContactBar contact={contact} />
-        </div>
+        </Wrapper>
       ) : (
         <p>Now loading...</p>
       )}
-    </div>
+    </Container>
   );
 }

--- a/src/services/MapApiService.js
+++ b/src/services/MapApiService.js
@@ -10,6 +10,7 @@ export default class MapApiService {
     const url = `${baseUrl}/map`;
     const params = { sido, sigungu, category };
     const { data } = await axios.get(url, { params });
+    console.log(data);
     return data.places;
   }
 

--- a/src/stores/MapStore.js
+++ b/src/stores/MapStore.js
@@ -36,7 +36,6 @@ export default class MapStore {
 
   selectedPlaceShortInformation(id) {
     this.selectedPlace = this.places.find((value) => value.placeId === id);
-    console.log(this.selectedPlace, 'selectedPlaceShort');
     this.publish();
   }
 

--- a/src/utils/KakaoMap.js
+++ b/src/utils/KakaoMap.js
@@ -26,19 +26,19 @@ function makeOutListener(infowindow) {
 //   new kakao.maps.Point(13, 34),
 // );
 
-export function loadMarkers(positions, map, makeClickListener) {
+export function loadMarkers(places, map, makeClickListener) {
   const markers = [];
 
-  for (let i = 0; i < positions.length; i += 1) {
+  for (let i = 0; i < places.length; i += 1) {
     const marker = new kakao.maps.Marker({
       map,
-      id: positions[i].placeId,
-      position: new kakao.maps.LatLng(positions[i].latitude, positions[i].longitude),
+      id: places[i].placeId,
+      position: new kakao.maps.LatLng(places[i].position.latitude, places[i].position.longitude),
     });
 
     // 인포 윈도우 생성
     const infowindow = new kakao.maps.InfoWindow({
-      content: positions[i].name,
+      content: places[i].name,
     });
 
     // 마커 위에 마우스 오버 시 인포 윈도우 띄우는 역할
@@ -59,7 +59,7 @@ export function loadMarkers(positions, map, makeClickListener) {
     kakao.maps.event.addListener(
       marker,
       'click',
-      () => makeClickListener(positions[i].placeId),
+      () => makeClickListener(places[i].placeId),
     );
 
     markers.push(marker);
@@ -94,7 +94,7 @@ export function loadMarkers(positions, map, makeClickListener) {
   clusterer.addMarkers(markers);
 }
 
-export function loadKakaoMap(component, positions, makeClickListener) {
+export function loadKakaoMap(component, places, makeClickListener) {
   const options = {
     center: new kakao.maps.LatLng(37.565804, 126.975146),
     level: 12,
@@ -104,7 +104,7 @@ export function loadKakaoMap(component, positions, makeClickListener) {
 
   loadZoomController(map);
 
-  loadMarkers(positions, map, makeClickListener);
+  loadMarkers(places, map, makeClickListener);
 
   return map;
 }


### PR DESCRIPTION
장소 상세보기 페이지 하단 연락처 네비게이션 바 1차 ui 구현
- 홈페이지 버튼 클릭 시 새 탭(또는 새창)으로 DB에 저장된 장소 관련 홈페이지로 이동(현재 작동여부를 확인하기 위해 임의로 메가테라 홈페이지로 설정)

<img width="483" alt="스크린샷 2022-11-09 오후 7 27 28" src="https://user-images.githubusercontent.com/104840243/200806240-1dfc6f54-465a-488f-983a-2a0ab064bf9a.png">
