### PR TITLE
장소 상세정보 내 블로그 리뷰 탭 UI 및 로직 구현

### DIFF
--- a/src/components/PlaceBlogReviews.jsx
+++ b/src/components/PlaceBlogReviews.jsx
@@ -1,0 +1,5 @@
+export default function PlaceBlogReviews({ blogReviews }) {
+  return (
+    <p>네이버 블로그 리뷰</p>
+  );
+}

--- a/src/components/PlaceBlogReviews.jsx
+++ b/src/components/PlaceBlogReviews.jsx
@@ -1,5 +1,110 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  padding: 3em 0;
+`;
+
+const Title = styled.h2`
+  font-size: 1.5em;
+  font-weight: bold;
+  padding-left: 2em;
+
+  strong {
+    color: #08ce5b;
+  }
+`;
+
+const Wrapper = styled.article`
+  padding: 0 3em;    
+`;
+
+const Review = styled.button`
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  width: 100%;
+  height: 120px;
+  margin: 1.5em 0;
+  border: 1px solid #DDD;
+  border-radius: 8px;
+  background-color: #fafafa;
+`;
+
+const ContentArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 1em .5em;
+
+    .title {
+      text-align: left;
+      font-size: 1.2em;
+      font-weight: bold;
+      margin: .5em 0;
+    }
+
+    .date {
+      margin: .2em 0;
+    }
+
+    .author {
+      color: #AAA;
+    }
+`;
+
+const ImageArea = styled.div`
+    width: 13em;
+    overflow: hidden;
+    border-radius: 10px;
+    margin-top: 4px;
+
+    img {
+        width: 13em;
+        height: 8em;
+        object-fit: cover;
+    }
+`;
+
+const NoneMessage = styled.p`
+  font-size: 1.2em;
+  text-align: center;
+  margin-top: 5em;
+`;
+
 export default function PlaceBlogReviews({ blogReviews }) {
   return (
-    <p>네이버 블로그 리뷰</p>
+    <Container>
+      <Title>
+        <strong>네이버</strong>
+        {' '}
+        블로그 리뷰
+      </Title>
+      {blogReviews.length !== 0 ? (
+        <Wrapper>
+          <ul>
+            {blogReviews.map((blogReview) => (
+              <li key={blogReview.id}>
+                <Review type="button" onClick={() => window.open(blogReview.url, '_blank')}>
+                  <ContentArea>
+                    <p className="title">{blogReview.title}</p>
+                    <p className="date">{blogReview.date}</p>
+                    <p className="author">
+                      by.
+                      {' '}
+                      {blogReview.author}
+                    </p>
+                  </ContentArea>
+                  <ImageArea>
+                    <img src={blogReview.imageSource} alt="" />
+                  </ImageArea>
+                </Review>
+              </li>
+            ))}
+          </ul>
+        </Wrapper>
+      ) : (
+        <NoneMessage>등록된 리뷰가 없습니다 😓</NoneMessage>
+      )}
+
+    </Container>
   );
 }

--- a/src/components/PlaceBlogReviews.test.jsx
+++ b/src/components/PlaceBlogReviews.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import PlaceBlogReviews from './PlaceBlogReviews';
+
+const context = describe;
+
+describe('PlaceBlogReviews', () => {
+  function renderPlaceBlogReviews() {
+    render(<PlaceBlogReviews />);
+  }
+
+  context('A user click placeBlogReviews tap', () => {
+    beforeEach(() => {
+      renderPlaceBlogReviews();
+    });
+
+    it('renders PlaceBlogReviews', () => {
+      screen.getByText('네이버 블로그 리뷰');
+    });
+  });
+});

--- a/src/components/PlaceDetailTap.jsx
+++ b/src/components/PlaceDetailTap.jsx
@@ -1,13 +1,17 @@
 export default function PlaceDetailTap({
   handlePlaceDetailCloseClick, handleBookmarkClick, handlePlaceDetailTapClick,
-  handleBlogReviewTapClick, handlePlaceRateAndReviewTapClick,
+  handleBlogReviewTapClick, handlePlaceRateAndReviewTapClick, size,
 }) {
   return (
     <nav>
       <button type="button" onClick={handlePlaceDetailCloseClick}> &lt; 뒤로가기</button>
       <button type="button" onClick={handleBookmarkClick}> 즐겨찾기</button>
       <button type="button" onClick={handlePlaceDetailTapClick}>상세정보</button>
-      <button type="button" onClick={handleBlogReviewTapClick}>블로그 리뷰 11</button>
+      <button type="button" onClick={handleBlogReviewTapClick}>
+        블로그 리뷰
+        {' '}
+        {size}
+      </button>
       <button type="button" onClick={handlePlaceRateAndReviewTapClick}>평점/리뷰</button>
     </nav>
   );

--- a/src/components/PlaceDetailTap.jsx
+++ b/src/components/PlaceDetailTap.jsx
@@ -1,0 +1,14 @@
+export default function PlaceDetailTap({
+  handlePlaceDetailCloseClick, handleBookmarkClick, handlePlaceDetailTapClick,
+  handleBlogReviewTapClick, handlePlaceRateAndReviewTapClick,
+}) {
+  return (
+    <nav>
+      <button type="button" onClick={handlePlaceDetailCloseClick}> &lt; 뒤로가기</button>
+      <button type="button" onClick={handleBookmarkClick}> 즐겨찾기</button>
+      <button type="button" onClick={handlePlaceDetailTapClick}>상세정보</button>
+      <button type="button" onClick={handleBlogReviewTapClick}>블로그 리뷰 11</button>
+      <button type="button" onClick={handlePlaceRateAndReviewTapClick}>평점/리뷰</button>
+    </nav>
+  );
+}

--- a/src/components/PlaceDetailTap.test.jsx
+++ b/src/components/PlaceDetailTap.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { contextId } from 'process';
+import PlaceDetailTap from './PlaceDetailTap';
+
+const context = describe;
+describe('PlaceDetailTap', () => {
+  function renderPlaceDetailTap() {
+    render(<PlaceDetailTap />);
+  }
+
+  context('A user enters the place detail page', () => {
+    beforeEach(() => {
+      renderPlaceDetailTap();
+    });
+
+    it('renders PlaceDetailTap top on the page', () => {
+      screen.getByText('상세정보');
+      screen.getByText('블로그 리뷰');
+      screen.getByText('평점/리뷰');
+    });
+  });
+});

--- a/src/components/PlaceLocationFilter.jsx
+++ b/src/components/PlaceLocationFilter.jsx
@@ -67,14 +67,6 @@ export default function PlaceLocationFilter({
   return (
     <Container>
       <Title>어디로 갈까요?</Title>
-      {/* <select onChange={() => handleSidoChange(this)}>
-        <option selected disabled hidden>선택</option>
-        {sidoArray.map((value) => (
-          <option key={value.id} value={value.ko}>
-            {value.ko}
-          </option>
-        ))}
-      </select> */}
       <SidoSection>
         <p>시/도</p>
         <SidoList>

--- a/src/components/PlaceRateAndReview.jsx
+++ b/src/components/PlaceRateAndReview.jsx
@@ -1,0 +1,8 @@
+export default function PlaceRateAndReview() {
+  return (
+    <div>
+      <p>내가 남긴 리뷰</p>
+      <p>회원님들의 리뷰</p>
+    </div>
+  );
+}

--- a/src/components/PlaceRateAndReview.test.jsx
+++ b/src/components/PlaceRateAndReview.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import PlaceRateAndReview from './PlaceRateAndReview';
+
+const context = describe;
+describe('PlaceRateAndReview', () => {
+  function renderPlaceRateandReview() {
+    render(<PlaceRateAndReview />);
+  }
+
+  context('A user clicks Rate and Review tap', () => {
+    beforeEach(() => {
+      renderPlaceRateandReview();
+    });
+
+    it('renders PlaceRateAndReview', () => {
+      screen.getByText('내가 남긴 리뷰');
+      screen.getByText('회원님들의 리뷰');
+    });
+  });
+});

--- a/src/hooks/useBlogReviewStore.js
+++ b/src/hooks/useBlogReviewStore.js
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { blogReviewStore } from '../stores/BlogReveiwStore';
+
+import useForceUpdate from './useForceUpdate';
+
+export default function useBlogReviewStore() {
+  const forceUpdate = useForceUpdate();
+
+  useEffect(() => {
+    blogReviewStore.subscribe(forceUpdate);
+
+    return () => blogReviewStore.unsubscribe(forceUpdate);
+  }, [forceUpdate]);
+
+  return blogReviewStore;
+}

--- a/src/pages/PlaceDetailPage.jsx
+++ b/src/pages/PlaceDetailPage.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import PlaceBlogReviews from '../components/PlaceBlogReviews';
 import PlaceContactBar from '../components/PlaceContactBar';
 import PlaceDetail from '../components/PlaceDetail';
+import PlaceDetailTap from '../components/PlaceDetailTap';
+import PlaceRateAndReview from '../components/PlaceRateAndReview';
+import useBlogReviewStore from '../hooks/useBlogReviewStore';
 import useMapStore from '../hooks/useMapStore';
 
 const Container = styled.div`
@@ -12,20 +16,27 @@ const Wrapper = styled.div`
 `;
 
 export default function PlaceDetailPage() {
+  const [isPlaceDetailOpen, setIsPlaceDetailOpen] = useState(true);
+  const [isBlogReviewOpen, setIsBlogReviewOpen] = useState(false);
+  const [isRateAndReviewOpen, setIsRateAndReviewOpen] = useState(true);
   const [isContactModalOpen, setIsContactModalOpen] = useState(false);
 
   const mapStore = useMapStore();
+  const blogReviewStore = useBlogReviewStore();
 
-  const path = document.location.pathname;
+  const placeId = document.location.pathname.split('/')[2];
 
   useEffect(() => {
-    mapStore.fetchSelectedPlaceDetail(path.split('/')[2]);
+    mapStore.fetchSelectedPlaceDetail(placeId);
+    blogReviewStore.fetchBlogReviews(placeId);
   }, []);
 
   const { selectedPlace, imageNumber } = mapStore;
   const {
     imageSource, address, placeServices, contact,
   } = selectedPlace;
+
+  const { blogReviews } = blogReviewStore;
 
   const handlePlaceDetailCloseClick = () => {
     //
@@ -36,15 +47,21 @@ export default function PlaceDetailPage() {
   };
 
   const handlePlaceDetailTapClick = () => {
-    //
+    setIsPlaceDetailOpen(true);
+    setIsBlogReviewOpen(false);
+    setIsRateAndReviewOpen(false);
   };
 
   const handleBlogReviewTapClick = () => {
-    //
+    setIsPlaceDetailOpen(false);
+    setIsBlogReviewOpen(true);
+    setIsRateAndReviewOpen(false);
   };
 
-  const handlePlaceRatingAndReviewTapClick = () => {
-    //
+  const handlePlaceRateAndReviewTapClick = () => {
+    setIsPlaceDetailOpen(false);
+    setIsBlogReviewOpen(false);
+    setIsRateAndReviewOpen(true);
   };
 
   const handlePrevImageClick = () => {
@@ -71,18 +88,28 @@ export default function PlaceDetailPage() {
     <Container>
       {selectedPlace && imageSource && address ? (
         <Wrapper>
-          <button type="button" onClick={handlePlaceDetailCloseClick}> &lt; 뒤로가기</button>
-          <button type="button" onClick={handleBookmarkClick}> 즐겨찾기</button>
-          <button type="button" onClick={handlePlaceDetailTapClick}>상세정보</button>
-          <button type="button" onClick={handleBlogReviewTapClick}>블로그 리뷰 11</button>
-          <button type="button" onClick={handlePlaceRatingAndReviewTapClick}>평점/리뷰</button>
-          <PlaceDetail
-            imageNumber={imageNumber}
-            selectedPlace={selectedPlace}
-            handlePrevImageClick={handlePrevImageClick}
-            handlNextImageClick={handlNextImageClick}
-            handleAddressCopyClick={handleAddressCopyClick}
+          <PlaceDetailTap
+            handlePlaceDetailCloseClick={handlePlaceDetailCloseClick}
+            handleBookmarkClick={handleBookmarkClick}
+            handlePlaceDetailTapClick={handlePlaceDetailTapClick}
+            handleBlogReviewTapClick={handleBlogReviewTapClick}
+            handlePlaceRateAndReviewTapClick={handlePlaceRateAndReviewTapClick}
           />
+          {isPlaceDetailOpen && (
+            <PlaceDetail
+              imageNumber={imageNumber}
+              selectedPlace={selectedPlace}
+              handlePrevImageClick={handlePrevImageClick}
+              handlNextImageClick={handlNextImageClick}
+              handleAddressCopyClick={handleAddressCopyClick}
+            />
+          )}
+          {isBlogReviewOpen && (
+            <PlaceBlogReviews
+              blogReviews={blogReviews}
+            />
+          )}
+          {isRateAndReviewOpen && <PlaceRateAndReview />}
           <PlaceContactBar
             contact={contact}
             toggleContactModal={toggleContactModal}

--- a/src/pages/PlaceDetailPage.jsx
+++ b/src/pages/PlaceDetailPage.jsx
@@ -94,6 +94,7 @@ export default function PlaceDetailPage() {
             handlePlaceDetailTapClick={handlePlaceDetailTapClick}
             handleBlogReviewTapClick={handleBlogReviewTapClick}
             handlePlaceRateAndReviewTapClick={handlePlaceRateAndReviewTapClick}
+            size={blogReviews?.length || 0}
           />
           {isPlaceDetailOpen && (
             <PlaceDetail

--- a/src/services/BlogReviewApiService.js
+++ b/src/services/BlogReviewApiService.js
@@ -1,0 +1,16 @@
+/* eslint-disable class-methods-use-this */
+import axios from 'axios';
+
+import config from '../config';
+
+const baseUrl = config.apiBaseUrl;
+
+export default class BlogReviewApiService {
+  async fetchBlogReviews(id) {
+    const url = `${baseUrl}/blog-reviews/${id}`;
+    const { data } = await axios.get(url);
+    return data;
+  }
+}
+
+export const blogReviewApiService = new BlogReviewApiService();

--- a/src/services/BlogReviewApiService.js
+++ b/src/services/BlogReviewApiService.js
@@ -6,10 +6,11 @@ import config from '../config';
 const baseUrl = config.apiBaseUrl;
 
 export default class BlogReviewApiService {
-  async fetchBlogReviews(id) {
-    const url = `${baseUrl}/blog-reviews/${id}`;
+  async fetchBlogReviews(placeId) {
+    const url = `${baseUrl}/blog-reviews/${placeId}`;
     const { data } = await axios.get(url);
-    return data;
+
+    return data.blogReviews;
   }
 }
 

--- a/src/services/MapApiService.js
+++ b/src/services/MapApiService.js
@@ -10,7 +10,6 @@ export default class MapApiService {
     const url = `${baseUrl}/map`;
     const params = { sido, sigungu, category };
     const { data } = await axios.get(url, { params });
-    console.log(data);
     return data.places;
   }
 

--- a/src/stores/BlogReveiwStore.js
+++ b/src/stores/BlogReveiwStore.js
@@ -1,0 +1,29 @@
+import { blogReviewApiService } from '../services/BlogReviewApiService';
+
+export default class BlogReviewStore {
+  constructor() {
+    this.listeners = new Set();
+
+    this.blogReveiws = [];
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+  }
+
+  unsubscribe(listener) {
+    this.listeners.delete(listener);
+  }
+
+  publish() {
+    this.listeners.forEach((listener) => listener());
+  }
+
+  async fetchBlogReviews(id) {
+    const blogReviews = await blogReviewApiService.fetchBlogReviews(id);
+    this.blogReviews = blogReviews;
+    this.publish();
+  }
+}
+
+export const blogReviewStore = new BlogReviewStore();

--- a/src/stores/BlogReveiwStore.test.js
+++ b/src/stores/BlogReveiwStore.test.js
@@ -1,0 +1,18 @@
+import BlogReviewStore from './BlogReveiwStore';
+
+const context = describe;
+
+describe('BlogReviewStore', () => {
+  let blogReviewStore;
+
+  beforeEach(() => {
+    blogReviewStore = new BlogReviewStore();
+  });
+
+  context('A user clicks a blog review tap about place id 4', () => {
+    it('loads blog reviews related the place id 4', () => {
+      // TODO
+      blogReviewStore.fetchBlogReviews(4);
+    });
+  });
+});


### PR DESCRIPTION
- 장소 상세정보의 블로그 리뷰 클릭 시 해당 장소 id(placeId)에 따른 블로그 리뷰를 서버에서 가져옴
- 블로그 리뷰가 아래 사진과 같이 4개 있을 경우 탭에 4개 숫자가 표기되며, 블로그 글, 썸네일 사진, 작성일, 포스팅 작성자가 리스트로 출력됨
<img width="496" alt="스크린샷 2022-11-10 오후 3 34 35" src="https://user-images.githubusercontent.com/104840243/201017727-8379e88b-7ea3-4cab-8ac2-d142cb8efe3f.png">

---
- 블로그 리뷰가 없을 경우 별도의 안내 문구가 출력됨
<img width="511" alt="스크린샷 2022-11-10 오후 3 36 08" src="https://user-images.githubusercontent.com/104840243/201017964-63869817-a28b-4909-a555-ff74cdd0bad1.png">